### PR TITLE
feat: add --num-calls parameter for multiple API calls per model

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,18 @@ python3 main.py "You are a helpful assistant" "Explain quantum computing" --tier
 python3 main.py "You are a helpful assistant" "Explain quantum computing" --tier luxury
 ```
 
+### Multiple Calls for Consistency Testing
+```bash
+# Make 5 calls to OpenAI to test response consistency
+python3 main.py "You are a helpful assistant" "Explain quantum computing" --provider openai --num-calls 5
+
+# Compare all providers with 3 calls each
+python3 main.py "You are a helpful assistant" "Explain quantum computing" --num-calls 3
+
+# Luxury tier with multiple calls for high-quality analysis
+python3 main.py "You are a helpful assistant" "Explain quantum computing" --tier luxury --num-calls 10
+```
+
 ### Save Results
 ```bash
 python3 main.py "You are a helpful assistant" "Explain quantum computing" --output results.json
@@ -117,6 +129,7 @@ python3 main.py "You are a helpful assistant" "Explain quantum computing" --outp
 ### Generation Parameters
 - `--max-tokens INT`: Maximum tokens per response (default: 1024)
 - `--temperature FLOAT`: Sampling temperature for OpenAI/Gemini (default: 0.7)
+- `--num-calls INT`: Number of calls to make to each model with the same prompt (default: 1)
 
 ### Output Options
 - `--output FILE`: Save results to JSON file
@@ -196,9 +209,17 @@ See `requirements.txt` for full dependencies. Main requirements:
 The tool includes comprehensive error handling for:
 - Missing API keys with helpful setup instructions
 - API authentication issues
-- Network errors
+- Network errors and timeouts
+- Rate limiting and server overload (with automatic retry)
 - Invalid parameters
 - Provider-specific errors
+
+### Automatic Retry Logic
+All providers now include intelligent retry logic for temporary failures:
+- **Exponential backoff**: 1s → 2s → 4s wait times
+- **Smart error detection**: Only retries on temporary errors (rate limits, server overload)
+- **User feedback**: Shows retry attempts in real-time
+- **Graceful fallback**: Returns error message if all retries fail
 
 ## Cost Tracking
 

--- a/src/ai_clients/claude_client.py
+++ b/src/ai_clients/claude_client.py
@@ -8,57 +8,76 @@ Claude API client for making requests to Anthropic's API
 
 import anthropic
 import os
+import time
+import random
 
-def call_claude_with_prompts(system_prompt, human_prompt, model="claude-3-5-sonnet-20241022", max_tokens=1024):
+def call_claude_with_prompts(system_prompt, human_prompt, model="claude-3-5-sonnet-20241022", max_tokens=1024, max_retries=3):
     """
-    Call Claude API with system and human prompts
-    
+    Call Claude API with system and human prompts, with retry logic for overload errors
+
     Args:
         system_prompt (str): The system prompt to set Claude's behavior
         human_prompt (str): The human's message/question
         model (str): Claude model to use
         max_tokens (int): Maximum tokens in response
-    
+        max_retries (int): Maximum number of retries for overload errors
+
     Returns:
         dict: Dictionary with content, usage, model, and provider information
     """
-    try:
-        # Initialize the client (will use ANTHROPIC_API_KEY from environment)
-        client = anthropic.Anthropic()
-        
-        # Create the message
-        message = client.messages.create(
-            model=model,
-            max_tokens=max_tokens,
-            system=system_prompt,  # System prompt goes here
-            messages=[
-                {"role": "user", "content": human_prompt}
-            ]
-        )
-        
-        # Extract usage information
-        usage = message.usage
-        input_tokens = usage.input_tokens if usage else 0
-        output_tokens = usage.output_tokens if usage else 0
-        
-        return {
-            "content": message.content[0].text,
-            "usage": {
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens
-            },
-            "model": model,
-            "provider": "claude"
-        }
-        
-    except Exception as e:
-        return {
-            "content": f"Error calling Claude: {str(e)}",
-            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-            "model": model,
-            "provider": "claude"
-        }
+
+    for attempt in range(max_retries + 1):
+        try:
+            # Initialize the client (will use ANTHROPIC_API_KEY from environment)
+            client = anthropic.Anthropic()
+
+            # Create the message
+            message = client.messages.create(
+                model=model,
+                max_tokens=max_tokens,
+                system=system_prompt,  # System prompt goes here
+                messages=[
+                    {"role": "user", "content": human_prompt}
+                ]
+            )
+
+            # Extract usage information
+            usage = message.usage
+            input_tokens = usage.input_tokens if usage else 0
+            output_tokens = usage.output_tokens if usage else 0
+
+            return {
+                "content": message.content[0].text,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens
+                },
+                "model": model,
+                "provider": "claude"
+            }
+
+        except Exception as e:
+            error_str = str(e)
+
+            # Check if this is an overload error (529) and we have retries left
+            if "529" in error_str or "overloaded" in error_str.lower():
+                if attempt < max_retries:
+                    # Exponential backoff with jitter: 2^attempt + random(0-1) seconds
+                    wait_time = (2 ** attempt) + random.random()
+                    print(f"  Claude overloaded (attempt {attempt + 1}/{max_retries + 1}), retrying in {wait_time:.1f}s...")
+                    time.sleep(wait_time)
+                    continue
+                else:
+                    error_str = f"Claude overloaded after {max_retries + 1} attempts: {error_str}"
+
+            # For non-overload errors or exhausted retries, return error
+            return {
+                "content": f"Error calling Claude: {error_str}",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "model": model,
+                "provider": "claude"
+            }
 
 def check_api_key():
     """

--- a/src/ai_clients/gemini_client.py
+++ b/src/ai_clients/gemini_client.py
@@ -8,72 +8,93 @@ Google Gemini API client for making requests to Google's Gemini API
 
 import google.generativeai as genai
 import os
+import time
+import random
 
-def call_gemini_with_prompts(system_prompt, human_prompt, model="gemini-1.5-pro", max_tokens=1024, temperature=0.7):
+def call_gemini_with_prompts(system_prompt, human_prompt, model="gemini-1.5-pro", max_tokens=1024, temperature=0.7, max_retries=3):
     """
-    Call Gemini API with system and human prompts
-    
+    Call Gemini API with system and human prompts, with retry logic for rate limits and server errors
+
     Args:
         system_prompt (str): The system prompt to set model's behavior
         human_prompt (str): The human's message/question
         model (str): Gemini model to use
         max_tokens (int): Maximum tokens in response
         temperature (float): Sampling temperature (0-2)
-    
+        max_retries (int): Maximum number of retries for rate limits/server errors
+
     Returns:
         dict: Response with content and usage information
     """
-    try:
-        # Configure the API key
-        genai.configure(api_key=os.getenv('GEMINI_API_KEY'))
-        
-        # Initialize the model
-        model_instance = genai.GenerativeModel(
-            model_name=model,
-            system_instruction=system_prompt
-        )
-        
-        # Configure generation parameters
-        generation_config = genai.types.GenerationConfig(
-            max_output_tokens=max_tokens,
-            temperature=temperature
-        )
-        
-        # Generate response
-        response = model_instance.generate_content(
-            human_prompt,
-            generation_config=generation_config
-        )
-        
-        # Extract usage information (Gemini API may not always provide detailed usage)
-        usage_metadata = response.usage_metadata if hasattr(response, 'usage_metadata') else None
-        
-        if usage_metadata:
-            input_tokens = usage_metadata.prompt_token_count
-            output_tokens = usage_metadata.candidates_token_count
-        else:
-            # Estimate tokens if not provided (rough approximation: 1 token ≈ 4 characters)
-            input_tokens = len(system_prompt + human_prompt) // 4
-            output_tokens = len(response.text) // 4
-        
-        return {
-            "content": response.text,
-            "usage": {
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens
-            },
-            "model": model,
-            "provider": "gemini"
-        }
-        
-    except Exception as e:
-        return {
-            "content": f"Error calling Gemini: {str(e)}",
-            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-            "model": model,
-            "provider": "gemini"
-        }
+
+    for attempt in range(max_retries + 1):
+        try:
+            # Configure the API key
+            genai.configure(api_key=os.getenv('GEMINI_API_KEY'))
+
+            # Initialize the model
+            model_instance = genai.GenerativeModel(
+                model_name=model,
+                system_instruction=system_prompt
+            )
+
+            # Configure generation parameters
+            generation_config = genai.types.GenerationConfig(
+                max_output_tokens=max_tokens,
+                temperature=temperature
+            )
+
+            # Generate response
+            response = model_instance.generate_content(
+                human_prompt,
+                generation_config=generation_config
+            )
+
+            # Extract usage information (Gemini API may not always provide detailed usage)
+            usage_metadata = response.usage_metadata if hasattr(response, 'usage_metadata') else None
+
+            if usage_metadata:
+                input_tokens = usage_metadata.prompt_token_count
+                output_tokens = usage_metadata.candidates_token_count
+            else:
+                # Estimate tokens if not provided (rough approximation: 1 token ≈ 4 characters)
+                input_tokens = len(system_prompt + human_prompt) // 4
+                output_tokens = len(response.text) // 4
+
+            return {
+                "content": response.text,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens
+                },
+                "model": model,
+                "provider": "gemini"
+            }
+
+        except Exception as e:
+            error_str = str(e)
+
+            # Check if this is a retryable error (rate limits, quota exceeded, server errors) and we have retries left
+            retryable_errors = ["rate_limit", "quota", "429", "500", "502", "503", "504", "timeout", "overloaded", "resource_exhausted"]
+            is_retryable = any(err in error_str.lower() for err in retryable_errors)
+
+            if is_retryable and attempt < max_retries:
+                # Exponential backoff with jitter: 2^attempt + random(0-1) seconds
+                wait_time = (2 ** attempt) + random.random()
+                print(f"  Gemini error (attempt {attempt + 1}/{max_retries + 1}), retrying in {wait_time:.1f}s...")
+                time.sleep(wait_time)
+                continue
+            elif is_retryable:
+                error_str = f"Gemini error after {max_retries + 1} attempts: {error_str}"
+
+            # For non-retryable errors or exhausted retries, return error
+            return {
+                "content": f"Error calling Gemini: {error_str}",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "model": model,
+                "provider": "gemini"
+            }
 
 def check_gemini_api_key():
     """

--- a/src/ai_clients/openai_client.py
+++ b/src/ai_clients/openai_client.py
@@ -8,59 +8,80 @@ OpenAI API client for making requests to OpenAI's API
 
 import openai
 import os
+import time
+import random
 
-def call_openai_with_prompts(system_prompt, human_prompt, model="gpt-4", max_tokens=1024, temperature=0.7):
+def call_openai_with_prompts(system_prompt, human_prompt, model="gpt-4", max_tokens=1024, temperature=0.7, max_retries=3):
     """
-    Call OpenAI API with system and human prompts
-    
+    Call OpenAI API with system and human prompts, with retry logic for rate limits and server errors
+
     Args:
         system_prompt (str): The system prompt to set assistant's behavior
         human_prompt (str): The human's message/question
         model (str): OpenAI model to use
         max_tokens (int): Maximum tokens in response
         temperature (float): Sampling temperature (0-2)
-    
+        max_retries (int): Maximum number of retries for rate limits/server errors
+
     Returns:
         dict: Dictionary with content, usage, model, and provider information
     """
-    try:
-        # Initialize the client (will use OPENAI_API_KEY from environment)
-        client = openai.OpenAI()
-        
-        # Create the chat completion
-        response = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": system_prompt},
-                {"role": "user", "content": human_prompt}
-            ],
-            max_tokens=max_tokens,
-            temperature=temperature
-        )
-        
-        # Extract usage information
-        usage = response.usage
-        input_tokens = usage.prompt_tokens if usage else 0
-        output_tokens = usage.completion_tokens if usage else 0
-        
-        return {
-            "content": response.choices[0].message.content,
-            "usage": {
-                "input_tokens": input_tokens,
-                "output_tokens": output_tokens,
-                "total_tokens": input_tokens + output_tokens
-            },
-            "model": model,
-            "provider": "openai"
-        }
-        
-    except Exception as e:
-        return {
-            "content": f"Error calling OpenAI: {str(e)}",
-            "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
-            "model": model,
-            "provider": "openai"
-        }
+
+    for attempt in range(max_retries + 1):
+        try:
+            # Initialize the client (will use OPENAI_API_KEY from environment)
+            client = openai.OpenAI()
+
+            # Create the chat completion
+            response = client.chat.completions.create(
+                model=model,
+                messages=[
+                    {"role": "system", "content": system_prompt},
+                    {"role": "user", "content": human_prompt}
+                ],
+                max_tokens=max_tokens,
+                temperature=temperature
+            )
+
+            # Extract usage information
+            usage = response.usage
+            input_tokens = usage.prompt_tokens if usage else 0
+            output_tokens = usage.completion_tokens if usage else 0
+
+            return {
+                "content": response.choices[0].message.content,
+                "usage": {
+                    "input_tokens": input_tokens,
+                    "output_tokens": output_tokens,
+                    "total_tokens": input_tokens + output_tokens
+                },
+                "model": model,
+                "provider": "openai"
+            }
+
+        except Exception as e:
+            error_str = str(e)
+
+            # Check if this is a retryable error (rate limits, server errors) and we have retries left
+            retryable_errors = ["rate_limit", "429", "500", "502", "503", "504", "timeout", "overloaded"]
+            is_retryable = any(err in error_str.lower() for err in retryable_errors)
+
+            if is_retryable and attempt < max_retries:
+                # Exponential backoff with jitter: 2^attempt + random(0-1) seconds
+                wait_time = (2 ** attempt) + random.random()
+                print(f"  OpenAI error (attempt {attempt + 1}/{max_retries + 1}), retrying in {wait_time:.1f}s...")
+                time.sleep(wait_time)
+                continue
+            elif is_retryable:
+                error_str = f"OpenAI error after {max_retries + 1} attempts: {error_str}"
+
+            # For non-retryable errors or exhausted retries, return error
+            return {
+                "content": f"Error calling OpenAI: {error_str}",
+                "usage": {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                "model": model,
+                "provider": "openai"
+            }
 
 def check_openai_api_key():
     """


### PR DESCRIPTION
## 🚀 Feature: Multiple API Calls per Model

### What this PR adds:
- **New `--num-calls` parameter** to specify number of calls to each model
- **Consistency testing** - make multiple calls with same prompt to test model reliability  
- **Automatic retry logic** with exponential backoff for all three providers
- **Enhanced error handling** for rate limits, server overload, and temporary failures

### Use Cases:
- **Research**: Test response consistency across multiple calls
- **Quality assurance**: Verify model reliability and variance
- **Cost analysis**: Understand token usage patterns across multiple requests
- **Reliability testing**: Handle temporary API outages gracefully

### Examples:
```bash
# Test OpenAI consistency with 5 calls
python3 main.py "You are a helpful assistant" "Explain AI" --provider openai --num-calls 5

# Compare all providers with 3 calls each  
python3 main.py "You are a helpful assistant" "Explain AI" --num-calls 3